### PR TITLE
Make endopoints configurable.

### DIFF
--- a/lib/aws_cloud_search.rb
+++ b/lib/aws_cloud_search.rb
@@ -18,17 +18,25 @@ module AWSCloudSearch
   # for future reference in case AWS-CS updates to XML 1.1 char compliance
   #INVALID_CHAR_XML11 = /[^\u0001-\uD7FF\uE000-\uFFFD]/m
 
+  DEFAULT_OPTIONS = {
+    region: 'us-east-1',
+    endpoint_base_domain: 'cloudsearch.amazonaws.com',
+    configuration_url: 'https://cloudsearch.us-east-1.amazonaws.com'
+  }.freeze
 
-  def self.search_url(domain, region="us-east-1")
-    "http://search-#{domain}.#{region}.cloudsearch.amazonaws.com"
+  def self.search_url(domain, options={})
+    options = DEFAULT_OPTIONS.merge(options)
+    "http://search-#{domain}.#{options[:region]}.#{options[:endpoint_base_domain]}"
   end
 
-  def self.document_url(domain, region="us-east-1")
-    "http://doc-#{domain}.#{region}.cloudsearch.amazonaws.com"
+  def self.document_url(domain, options={})
+    options = DEFAULT_OPTIONS.merge(options)
+    "http://doc-#{domain}.#{options[:region]}.#{options[:endpoint_base_domain]}"
   end
 
-  def self.configuration_url
-    "https://cloudsearch.us-east-1.amazonaws.com"
+  def self.configuration_url(options={})
+    options = DEFAULT_OPTIONS.merge(options)
+    options[:configuration_url]
   end
 
   # Initialize the module

--- a/lib/aws_cloud_search/cloud_search.rb
+++ b/lib/aws_cloud_search/cloud_search.rb
@@ -3,10 +3,9 @@ require "aws_cloud_search"
 
 module AWSCloudSearch
   class CloudSearch
-
-    def initialize(domain, region="us-east-1")
-      @doc_conn = AWSCloudSearch::create_connection( AWSCloudSearch::document_url(domain, region) )
-      @search_conn = AWSCloudSearch::create_connection( AWSCloudSearch::search_url(domain, region) )
+    def initialize(domain, options={})
+      @doc_conn = AWSCloudSearch::create_connection( AWSCloudSearch::document_url(domain, options) )
+      @search_conn = AWSCloudSearch::create_connection( AWSCloudSearch::search_url(domain, options) )
     end
 
     # Sends a batch of document updates and deletes by invoking the CloudSearch documents/batch API


### PR DESCRIPTION
We are now developing Groonga CluodSearch, an open source implementation of Amazon CloudSearch.
http://gcs.groonga.org/

Groonga CloudSearch can work with aws_cloud_search by monkey patching
that directs the requests toward the host running Groonga CloudSearch instead of Amazon CloudSearch.
http://gcs.groonga.org/blog/2012/07/25/work-with-aws-cloud-search-gem/

It would be great if aws_cloud_search can pick the base domain name of doc and search endpoints and URL of configuration endpoint. With this patch, we can initiate AWSCloudSearch::CloudSearch object like below:

``` ruby
cloud_search = AWSCloudSearch::CloudSearch.new(
  'example-00000000000000000000000000',
  endpoint_base_domain: '127.0.0.1.xip.io:7575',
  configuration_url: 'http://localhost:7575'
)
```

How do you think? I'd like to hear your thought.
