### PR TITLE
When document type is `delete`, there is no need to send `fields` attribute

### DIFF
--- a/lib/aws_cloud_search/document.rb
+++ b/lib/aws_cloud_search/document.rb
@@ -64,10 +64,13 @@ module AWSCloudSearch
       h = {
           :type => @type,
           :id => @id,
-          :version => @version,
-          :fields => @fields
+          :version => @version
       }
-      h[:lang] = @lang unless (@type == 'delete')
+
+      unless @type == 'delete'
+        h[:fields] = @fields 
+        h[:lang] = @lang
+      end
 
       h      
     end


### PR DESCRIPTION
In fact, doing so will result in a warning like:

```
 "message" => "\"delete\" has unknown attribute(s): ['fields'] (near operation with index 1; document_id developmentdrewslzimaclocal67)"
```

Note: Fix for messed up PR #10.
